### PR TITLE
WIP: Patch ZNetScene.InLoadingScreen for dedicated server.

### DIFF
--- a/src/Valheim_Serverside/ServersidePlugin.cs
+++ b/src/Valheim_Serverside/ServersidePlugin.cs
@@ -127,6 +127,16 @@ namespace Valheim_Serverside
 			}
 		}
 
+		[HarmonyPatch(typeof(ZNetScene), "InLoadingScreen")]
+		private static class ZNetScene_InLoadingScreen_Patch
+		{
+			private static bool Prefix(ref bool __result)
+			{
+				__result = false;
+				return false;
+			}
+		}
+
 		[HarmonyPatch(typeof(ZoneSystem), "Update")]
 		static class ZoneSystem_Update_Patch
 		/*


### PR DESCRIPTION
On a dedicated server, this always returns false which means 100 objects created per second instead of 10.

Consider returning true if no peers are connected.