### PR TITLE
Fix objects not being created on the server in 0.150.3.

### DIFF
--- a/src/Valheim_Serverside/ServersidePlugin.cs
+++ b/src/Valheim_Serverside/ServersidePlugin.cs
@@ -130,7 +130,7 @@ namespace Valheim_Serverside
 		[HarmonyPatch(typeof(ZoneSystem), "IsActiveAreaLoaded")]
 		static class ZoneSystem_IsActiveAreaLoaded_Patch
 		{
-			private static bool Prefix(ZoneSystem __instance, ref bool __result)
+			private static bool Prefix(ZoneSystem __instance, ref bool __result, Dictionary<Vector2i, dynamic> ___m_zones)
 			{
 				foreach (ZNetPeer peer in ZNet.instance.GetPeers())
 				{
@@ -139,7 +139,7 @@ namespace Valheim_Serverside
 					{
 						for (int j = zone.x - __instance.m_activeArea; j <= zone.x + __instance.m_activeArea; j++)
 						{
-							if (!__instance.IsZoneLoaded(new Vector2i(j, i)))
+							if (!___m_zones.ContainsKey(new Vector2i(j, i)))
 							{
 								__result = false;
 								return false;


### PR DESCRIPTION
Patch ZoneSystem.IsActiveAreaLoaded to loop over all peers.