### PR TITLE
Fix assembly publicizer workflow and use assembly_valheim_publicized.dll

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -26,7 +26,8 @@ jobs:
     
     - name: Publicize assembly
       run: |
-        contrib/AssemblyPublicizer/AssemblyPublicizer.exe -i serverfiles\valheim_server_Data\Managed\assembly_valheim.dll -o serverfiles\valheim_server_Data\Managed\assembly_valheim_publicized.dll
+        cd serverfiles/valheim_server_Data/Managed
+        ../../../contrib/AssemblyPublicizer/AssemblyPublicizer.exe -i assembly_valheim.dll -o assembly_valheim_publicized.dll
         
     - name: build
       run: |

--- a/src/Valheim_Serverside/Serverside_Simulations.csproj
+++ b/src/Valheim_Serverside/Serverside_Simulations.csproj
@@ -43,9 +43,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(SolutionDir)\..\ValheimLibs\assembly_utils.dll</HintPath>
     </Reference>
-    <Reference Include="assembly_valheim, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="assembly_valheim_publicized, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\..\ValheimLibs\assembly_valheim.dll</HintPath>
+      <HintPath>$(SolutionDir)\..\ValheimLibs\assembly_valheim_publicized.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx, Version=5.4.8.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -98,7 +98,6 @@
     <Compile Include="ServersidePlugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition="'$(BuildingInsideVisualStudio)' == true">set SCRIPT=$(SolutionDir)\bin\post_build.bat


### PR DESCRIPTION
Working dir needs to be that of the DLL to avoid throwing an exception.

Add `_publicized` to module path so it's clear what we're using.