### PR TITLE
Fix private method access errors in Release build

### DIFF
--- a/src/Valheim_Serverside/ServersidePlugin.cs
+++ b/src/Valheim_Serverside/ServersidePlugin.cs
@@ -10,7 +10,7 @@ namespace Valheim_Serverside
 {
 
 	[Harmony]
-	[BepInPlugin("MVP.Valheim_Serverside_Simulations", "Serverside Simulations", "1.1.4")]
+	[BepInPlugin("MVP.Valheim_Serverside_Simulations", "Serverside Simulations", "1.1.5")]
 	[BepInDependency(ValheimPlusPluginId, BepInDependency.DependencyFlags.SoftDependency)]
 
 	public class ServersidePlugin : BaseUnityPlugin

--- a/src/Valheim_Serverside/Serverside_Simulations.csproj
+++ b/src/Valheim_Serverside/Serverside_Simulations.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>


### PR DESCRIPTION
Allow unsafe code on Release builds. Needed for the use of Assembly Publicizer.

Fixes #92
Fixes #94 
