### PR TITLE
Remove `AudioMan.Update`

### DIFF
--- a/src/Valheim_Serverside/Features/Core.cs
+++ b/src/Valheim_Serverside/Features/Core.cs
@@ -182,7 +182,7 @@ namespace Valheim_Serverside.Features
 						}
 						else if (
 							(zdoOwner == 0L
-							|| !new Traverse(__instance).Method("IsInPeerActiveArea", new object[] { zdo.GetSector(), zdo.GetOwner()}).GetValue<bool>()
+							|| !new Traverse(__instance).Method("IsInPeerActiveArea", new object[] { zdo.GetSector(), zdo.GetOwner() }).GetValue<bool>()
 							)
 							&& anyPlayerInArea
 						)

--- a/src/Valheim_Serverside/Features/Core.cs
+++ b/src/Valheim_Serverside/Features/Core.cs
@@ -475,5 +475,17 @@ namespace Valheim_Serverside.Features
 				return false;
 			}
 		}
+
+		[HarmonyPatch(typeof(AudioMan), "Update")]
+		public static class AudioMan_Update_Patch
+		/*
+			Skip `AudioMan.Update` on the server.
+		 */
+		{
+			static bool Prefix()
+			{
+				return false;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Over time we observe raised exceptions related to the audio system on the server, in an attempt to reduce such occurrences `AudioMan.Update` has been patched out.